### PR TITLE
Feat: Add convenience methods for common types

### DIFF
--- a/lib/src/beacon_settings.dart
+++ b/lib/src/beacon_settings.dart
@@ -198,13 +198,11 @@ extension SettingsX on Settings {
     required String key,
     int defaultValue = 0,
   }) {
-    final s = setting<int>(
+    return setting<int>(
       key: key,
       decode: intDecoder(defaultValue: defaultValue),
       encode: intEncoder(),
     );
-
-    return s;
   }
 
   /// Creates a new [Setting] that manages a [double].

--- a/lib/src/beacon_settings.dart
+++ b/lib/src/beacon_settings.dart
@@ -32,79 +32,6 @@ abstract class Settings {
     return s;
   }
 
-  /// Creates a new [Setting] that manages a [int].
-  ///
-  /// {@macro setting}
-  @protected
-  Setting<int> intSetting({
-    required String key,
-    int defaultValue = 0,
-  }) {
-    return setting(
-      key: key,
-      decode: intDecoder(defaultValue: defaultValue),
-      encode: intEncoder(),
-    );
-  }
-
-  /// Creates a new [Setting] that manages a [double].
-  ///
-  /// {@macro setting}
-  @protected
-  Setting<double> doubleSetting({
-    required String key,
-    double defaultValue = 0.0,
-  }) {
-    return setting(
-      key: key,
-      decode: doubleDecoder(defaultValue: defaultValue),
-      encode: doubleEncoder(),
-    );
-  }
-
-  /// Creates a new [Setting] that manages a [bool].
-  ///
-  /// {@macro setting}
-  @protected
-  Setting<bool> boolSetting({
-    required String key,
-    bool defaultValue = false,
-  }) {
-    return setting(
-      key: key,
-      decode: boolDecoder(defaultValue: defaultValue),
-      encode: boolEncoder(),
-    );
-  }
-
-  /// Creates a new [Setting] that manages a [String].
-  ///
-  /// {@macro setting}
-  @protected
-  Setting<String?> stringSetting({
-    required String key,
-  }) {
-    return setting(
-      key: key,
-      decode: nullableStringDecoder(),
-      encode: nullableStringEncoder(),
-    );
-  }
-
-  /// Creates a new [Setting] that manages a [List<String>].
-  ///
-  /// {@macro setting}
-  @protected
-  Setting<List<String>> stringListSetting({
-    required String key,
-  }) {
-    return setting(
-      key: key,
-      decode: stringListDecoder(),
-      encode: stringListEncoder(),
-    );
-  }
-
   /// Clears all settings by calling [Setting.reset] on each setting
   /// in the cache.
   void clear() {
@@ -262,6 +189,76 @@ extension SettingsX on Settings {
       name: 'derivedSettingEffect',
     );
     return s;
+  }
+
+  /// Creates a new [Setting] that manages an [int].
+  ///
+  /// {@macro setting}
+  Setting<int> intSetting({
+    required String key,
+    int defaultValue = 0,
+  }) {
+    final s = setting<int>(
+      key: key,
+      decode: intDecoder(defaultValue: defaultValue),
+      encode: intEncoder(),
+    );
+
+    return s;
+  }
+
+  /// Creates a new [Setting] that manages a [double].
+  ///
+  /// {@macro setting}
+  Setting<double> doubleSetting({
+    required String key,
+    double defaultValue = 0.0,
+  }) {
+    return setting<double>(
+      key: key,
+      decode: doubleDecoder(defaultValue: defaultValue),
+      encode: doubleEncoder(),
+    );
+  }
+
+  /// Creates a new [Setting] that manages a [bool].
+  ///
+  /// {@macro setting}
+  Setting<bool> boolSetting({
+    required String key,
+    bool defaultValue = false,
+  }) {
+    return setting<bool>(
+      key: key,
+      decode: boolDecoder(defaultValue: defaultValue),
+      encode: boolEncoder(),
+    );
+  }
+
+  /// Creates a new [Setting] that manages a [String].
+  ///
+  /// {@macro setting}
+  Setting<String?> stringSetting({
+    required String key,
+  }) {
+    return setting<String?>(
+      key: key,
+      decode: nullableStringDecoder(),
+      encode: nullableStringEncoder(),
+    );
+  }
+
+  /// Creates a new [Setting] that manages a [List<String>].
+  ///
+  /// {@macro setting}
+  Setting<List<String>> stringListSetting({
+    required String key,
+  }) {
+    return setting<List<String>>(
+      key: key,
+      decode: stringListDecoder(),
+      encode: stringListEncoder(),
+    );
   }
 }
 

--- a/lib/src/beacon_settings.dart
+++ b/lib/src/beacon_settings.dart
@@ -32,6 +32,79 @@ abstract class Settings {
     return s;
   }
 
+  /// Creates a new [Setting] that manages a [int].
+  ///
+  /// {@macro setting}
+  @protected
+  Setting<int> intSetting({
+    required String key,
+    int defaultValue = 0,
+  }) {
+    return setting(
+      key: key,
+      decode: intDecoder(defaultValue: defaultValue),
+      encode: intEncoder(),
+    );
+  }
+
+  /// Creates a new [Setting] that manages a [double].
+  ///
+  /// {@macro setting}
+  @protected
+  Setting<double> doubleSetting({
+    required String key,
+    double defaultValue = 0.0,
+  }) {
+    return setting(
+      key: key,
+      decode: doubleDecoder(defaultValue: defaultValue),
+      encode: doubleEncoder(),
+    );
+  }
+
+  /// Creates a new [Setting] that manages a [bool].
+  ///
+  /// {@macro setting}
+  @protected
+  Setting<bool> boolSetting({
+    required String key,
+    bool defaultValue = false,
+  }) {
+    return setting(
+      key: key,
+      decode: boolDecoder(defaultValue: defaultValue),
+      encode: boolEncoder(),
+    );
+  }
+
+  /// Creates a new [Setting] that manages a [String].
+  ///
+  /// {@macro setting}
+  @protected
+  Setting<String?> stringSetting({
+    required String key,
+  }) {
+    return setting(
+      key: key,
+      decode: nullableStringDecoder(),
+      encode: nullableStringEncoder(),
+    );
+  }
+
+  /// Creates a new [Setting] that manages a [List<String>].
+  ///
+  /// {@macro setting}
+  @protected
+  Setting<List<String>> stringListSetting({
+    required String key,
+  }) {
+    return setting(
+      key: key,
+      decode: stringListDecoder(),
+      encode: stringListEncoder(),
+    );
+  }
+
   /// Clears all settings by calling [Setting.reset] on each setting
   /// in the cache.
   void clear() {

--- a/test/src/beacon_settings_test.dart
+++ b/test/src/beacon_settings_test.dart
@@ -230,11 +230,7 @@ void main() {
 class TestSettings extends Settings {
   TestSettings(super.storage);
 
-  late final simpleBool = setting(
-    key: 'simpleBool',
-    decode: boolDecoder(),
-    encode: boolEncoder(),
-  ).value;
+  late final simpleBool = boolSetting(key: 'simpleBool').value;
 
   late final derivedSource = setting(
     key: 'derivedSource',
@@ -252,29 +248,13 @@ class TestSettings extends Settings {
     encode: intEncoder(),
   ).value;
 
-  late final simpleDouble = setting(
-    key: 'simpleDouble',
-    decode: doubleDecoder(),
-    encode: doubleEncoder(),
-  ).value;
+  late final simpleDouble = doubleSetting(key: 'simpleDouble').value;
 
-  late final simpleInt = setting(
-    key: 'simpleInt',
-    decode: intDecoder(),
-    encode: intEncoder(),
-  ).value;
+  late final simpleInt = intSetting(key: 'simpleInt').value;
 
-  late final simpleString = setting(
-    key: 'simpleString',
-    decode: nullableStringDecoder(),
-    encode: nullableStringEncoder(),
-  ).value;
+  late final simpleString = stringSetting(key: 'simpleString').value;
 
-  late final simpleList = setting(
-    key: 'simpleList',
-    decode: stringListDecoder(),
-    encode: stringListEncoder(),
-  ).value;
+  late final simpleList = stringListSetting(key: 'simpleList').value;
 
   late final invalid = setting(
     key: 'invalid',


### PR DESCRIPTION
Before:
```dart
late final isAwesome = setting(
    key: 'isAwesome',
    decode: boolDecoder(),
    encode: boolEncoder(),
  ).value;
```

After:

```dart
late final isAwesome = boolSetting(key: 'isAwesome').value;
```