### PR TITLE
fix: boolSetting returns incorrect value when persisted value does not equal default value

### DIFF
--- a/lib/src/beacon_settings.dart
+++ b/lib/src/beacon_settings.dart
@@ -274,7 +274,7 @@ Encoder<int> intEncoder() {
 /// Decoder for a [Setting] that manages a [bool]. If the value is not in
 /// the underlying [Storage], [defaultValue] is returned.
 Decoder<bool> boolDecoder({bool defaultValue = false}) {
-  return (value) => (value is BoolSettingValue && value.value) || defaultValue;
+  return (value) => value is BoolSettingValue ? value.value : defaultValue;
 }
 
 /// Encoder for a [Setting] that manages a [bool].


### PR DESCRIPTION
Fixes a bug that caused the `boolSetting` helper to return an incorrect value whenever the persisted value was not equal to the default value. In a Flutter app, this manifested as the setting being reset to the default whenever the app was restarted.